### PR TITLE
Determines volume, ndens and ndens^2 in terms of I_ij sums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,5 +27,8 @@ include-package-data = true
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+powercovfft = ["*/*.txt"]
+
 [project.urls]
 Homepage = "https://github.com/archaeo-pteryx/PowerSpecCovFFT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powercovfft"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   {name = "Yosuke Kobayashi", email = "yosukekobayashi@arizona.edu"},
 ]

--- a/src/powercovfft/cov.py
+++ b/src/powercovfft/cov.py
@@ -54,6 +54,21 @@ class PowerSpecCovFFT:
         self.fgrowth = fgrowth
         self.bias = bias
 
+    @property
+    def ndens2(self):
+        return self._ndens2 if hasattr(self, '_ndens2') else self.ndens**2
+    
+    @ndens2.setter
+    def ndens2(self, value):
+        self._ndens2 = value
+
+    def set_params_Iij(self, I22, I24, I34, I44, fgrowth, bias):
+        self.vol = I22**2 / I44
+        self.ndens = I44 / I34
+        self.ndens2 = I44 / I24
+        self.fgrowth = fgrowth
+        self.bias = bias
+
     def calc_master_integral(self, k1, k2, z_switch=0.1):
         k1 = np.atleast_1d(k1)
         k2 = np.atleast_1d(k2)
@@ -116,7 +131,7 @@ class PowerSpecCovFFT:
 
     def get_cov_T_SN_P(self, l1, l2, k1, k2):
         term = 2 * self.get_cov_T0_term(l1, l2, k1, k2, name='T_SN_P')
-        return term / self.ndens**2
+        return term / self.ndens2
 
     # main function to compute T0 part Eq. (7)
     def get_cov_T0(self, l1, l2, k1, k2):
@@ -158,7 +173,7 @@ class PowerSpecCovFFT:
         # T0 integrand from shot-noise terms
         term1 = 8 / self.ndens * self.get_pk_lin(k1) * self.cov_integrand['T_SN_B_2'](mu12, l1, l2, k1, k2, self.fgrowth, self.bias)
         term2 = 8 / self.ndens * self.get_pk_lin(k2) * self.cov_integrand['T_SN_B_2'](mu12, l1, l2, k2, k1, self.fgrowth, self.bias)
-        term3 = 2 / self.ndens**2 * self.cov_integrand['T_SN_P'](mu12, l1, l2, k1, k2, self.fgrowth, self.bias)
+        term3 = 2 / self.ndens2 * self.cov_integrand['T_SN_P'](mu12, l1, l2, k1, k2, self.fgrowth, self.bias)
 
         k12 = np.sqrt(k1**2 + k2**2 + 2 * k1 * k2 * mu12)
         integrand = self.get_pk_lin(k12) * (term1 + term2 + term3)


### PR DESCRIPTION
This pull request allows one to specify the volume, number density and number density squared in terms of sums:

$$I_{ij} = \int d^3x \\ \bar n^i(x) w^j(x) = \sum_i \bar n^{i-1} w^j$$

by making the replacements:

$$V \rightarrow \frac{I_{22}^2}{I_{44}}$$

$$\bar n \rightarrow \frac{I_{44}}{I_{34}}$$

$$\bar n ^2\rightarrow \frac{I_{44}}{I_{24}}$$

That can be made by calling the function `set_params_Iij(I22, I24, I34, I44, fgrowth, bias)`.

It is backward compatible. If the `nbar2` property is not defined, it is evaluated as `nbar^2`.

It also adds an extra line to `pyproject.toml` to make the `*.txt` files with the equations be copied when using `pip install`.